### PR TITLE
Add buswatch-sdk: instrumentation SDK for message bus metrics

### DIFF
--- a/buswatch-sdk/Cargo.toml
+++ b/buswatch-sdk/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "buswatch-sdk"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.75"
+authors = ["Matthew Hounslow"]
+description = "Instrumentation SDK for emitting message bus metrics to buswatch"
+license = "Apache-2.0"
+repository = "https://github.com/lowhung/buswatch"
+documentation = "https://docs.rs/buswatch-sdk"
+readme = "README.md"
+keywords = ["message-bus", "observability", "monitoring", "instrumentation", "metrics"]
+categories = ["development-tools::debugging", "development-tools::profiling"]
+
+[features]
+default = ["tokio"]
+tokio = ["dep:tokio"]
+
+[dependencies]
+buswatch-types = { path = "../buswatch-types", features = ["serde"] }
+serde_json = "1"
+parking_lot = "0.12"
+
+# Async runtime (optional, for background emission)
+tokio = { version = "1", features = ["time", "sync", "rt", "io-util", "net", "fs", "macros"], optional = true }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full", "test-util"] }

--- a/buswatch-sdk/README.md
+++ b/buswatch-sdk/README.md
@@ -1,0 +1,124 @@
+# buswatch-sdk
+
+Instrumentation SDK for emitting message bus metrics to buswatch.
+
+## Quick Start
+
+```rust
+use buswatch_sdk::{Instrumentor, Output};
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() {
+    // Create an instrumentor that emits snapshots every second
+    let instrumentor = Instrumentor::builder()
+        .output(Output::file("metrics.json"))
+        .interval(Duration::from_secs(1))
+        .build();
+
+    // Register a module and get a handle for recording metrics
+    let handle = instrumentor.register("my-service");
+
+    // Start background emission
+    instrumentor.start();
+
+    // Record metrics as your service processes messages
+    loop {
+        // ... receive a message ...
+        handle.record_read("orders.new", 1);
+        
+        // ... process and publish result ...
+        handle.record_write("orders.processed", 1);
+    }
+}
+```
+
+## Features
+
+- **Simple API**: Just `record_read()` and `record_write()`
+- **Multiple outputs**: File, TCP, or custom channel
+- **Background emission**: Automatic periodic snapshots
+- **Thread-safe**: Use from any thread or async task
+- **Backlog tracking**: Automatically computes unread message counts
+- **Pending tracking**: Track how long operations are blocked
+
+## Tracking Pending Operations
+
+For tracking how long read/write operations are blocked:
+
+```rust
+// Using guards (RAII style)
+let guard = handle.start_read("events");
+let message = queue.recv().await; // Blocking operation
+drop(guard); // Clears pending state
+handle.record_read("events", 1);
+
+// Or set pending time directly
+handle.set_read_pending("events", Some(Instant::now()));
+// ... do work ...
+handle.set_read_pending("events", None);
+```
+
+## Output Options
+
+### File Output
+
+```rust
+let instrumentor = Instrumentor::builder()
+    .output(Output::file("metrics.json"))
+    .build();
+```
+
+### TCP Output
+
+```rust
+let instrumentor = Instrumentor::builder()
+    .output(Output::tcp("localhost:9090"))
+    .build();
+```
+
+### Channel Output
+
+```rust
+let (output, mut rx) = Output::channel(16);
+
+let instrumentor = Instrumentor::builder()
+    .output(output)
+    .build();
+
+// Handle snapshots yourself
+tokio::spawn(async move {
+    while let Some(snapshot) = rx.recv().await {
+        // Custom handling
+    }
+});
+```
+
+### Multiple Outputs
+
+```rust
+let instrumentor = Instrumentor::builder()
+    .output(Output::file("metrics.json"))
+    .output(Output::tcp("localhost:9090"))
+    .build();
+```
+
+## Manual Emission
+
+If you prefer not to use background emission:
+
+```rust
+let instrumentor = Instrumentor::new();
+let handle = instrumentor.register("my-service");
+
+// Record metrics
+handle.record_read("events", 10);
+
+// Collect snapshot manually
+let snapshot = instrumentor.collect();
+println!("{}", serde_json::to_string_pretty(&snapshot).unwrap());
+```
+
+## License
+
+Apache-2.0

--- a/buswatch-sdk/src/handle.rs
+++ b/buswatch-sdk/src/handle.rs
@@ -1,0 +1,205 @@
+//! Module handle for recording metrics.
+
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Instant;
+
+use crate::state::{GlobalState, ModuleState};
+
+/// A handle for recording metrics for a specific module.
+///
+/// This is the primary interface for instrumenting your message bus.
+/// Obtain a handle by calling `Instrumentor::register()`.
+///
+/// # Example
+///
+/// ```rust
+/// use buswatch_sdk::Instrumentor;
+///
+/// let instrumentor = Instrumentor::new();
+/// let handle = instrumentor.register("my-service");
+///
+/// // Record a read from a topic
+/// handle.record_read("orders.new", 1);
+///
+/// // Record a write to a topic
+/// handle.record_write("orders.processed", 1);
+///
+/// // Track pending operations
+/// let guard = handle.start_read("orders.new");
+/// // ... do the read ...
+/// drop(guard); // Clears pending state
+/// ```
+#[derive(Clone)]
+pub struct ModuleHandle {
+    pub(crate) state: Arc<ModuleState>,
+    pub(crate) global: Arc<GlobalState>,
+    pub(crate) name: String,
+}
+
+impl ModuleHandle {
+    /// Record that messages were read from a topic.
+    ///
+    /// # Arguments
+    ///
+    /// * `topic` - The topic name
+    /// * `count` - Number of messages read
+    pub fn record_read(&self, topic: &str, count: u64) {
+        let read_state = self.state.get_or_create_read(topic);
+        read_state.count.fetch_add(count, Ordering::Relaxed);
+    }
+
+    /// Record that messages were written to a topic.
+    ///
+    /// # Arguments
+    ///
+    /// * `topic` - The topic name
+    /// * `count` - Number of messages written
+    pub fn record_write(&self, topic: &str, count: u64) {
+        let write_state = self.state.get_or_create_write(topic);
+        write_state.count.fetch_add(count, Ordering::Relaxed);
+
+        // Also update global write counter for backlog computation
+        let global_counter = self.global.get_topic_write_counter(topic);
+        global_counter.fetch_add(count, Ordering::Relaxed);
+    }
+
+    /// Start tracking a pending read operation.
+    ///
+    /// Returns a guard that clears the pending state when dropped.
+    /// This is useful for tracking how long reads are blocked.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use buswatch_sdk::Instrumentor;
+    /// # let instrumentor = Instrumentor::new();
+    /// # let handle = instrumentor.register("test");
+    /// let guard = handle.start_read("events");
+    /// // ... blocking read operation ...
+    /// drop(guard); // Clears pending state
+    /// handle.record_read("events", 1);
+    /// ```
+    pub fn start_read(&self, topic: &str) -> PendingGuard {
+        let read_state = self.state.get_or_create_read(topic);
+        *read_state.pending_since.write() = Some(Instant::now());
+
+        PendingGuard {
+            state: PendingState::Read(read_state),
+        }
+    }
+
+    /// Start tracking a pending write operation.
+    ///
+    /// Returns a guard that clears the pending state when dropped.
+    /// This is useful for tracking backpressure (slow consumers).
+    pub fn start_write(&self, topic: &str) -> PendingGuard {
+        let write_state = self.state.get_or_create_write(topic);
+        *write_state.pending_since.write() = Some(Instant::now());
+
+        PendingGuard {
+            state: PendingState::Write(write_state),
+        }
+    }
+
+    /// Set the pending duration for a read directly.
+    ///
+    /// Use this if you're computing pending time yourself rather than
+    /// using the guard-based API.
+    pub fn set_read_pending(&self, topic: &str, since: Option<Instant>) {
+        let read_state = self.state.get_or_create_read(topic);
+        *read_state.pending_since.write() = since;
+    }
+
+    /// Set the pending duration for a write directly.
+    pub fn set_write_pending(&self, topic: &str, since: Option<Instant>) {
+        let write_state = self.state.get_or_create_write(topic);
+        *write_state.pending_since.write() = since;
+    }
+
+    /// Get the module name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl std::fmt::Debug for ModuleHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ModuleHandle")
+            .field("name", &self.name)
+            .finish()
+    }
+}
+
+/// Internal state for pending guard.
+enum PendingState {
+    Read(Arc<crate::state::ReadState>),
+    Write(Arc<crate::state::WriteState>),
+}
+
+/// Guard that clears pending state when dropped.
+///
+/// This implements RAII-style tracking of pending operations.
+pub struct PendingGuard {
+    state: PendingState,
+}
+
+impl Drop for PendingGuard {
+    fn drop(&mut self) {
+        match &self.state {
+            PendingState::Read(s) => *s.pending_since.write() = None,
+            PendingState::Write(s) => *s.pending_since.write() = None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::GlobalState;
+
+    fn create_handle() -> ModuleHandle {
+        let global = Arc::new(GlobalState::default());
+        let state = global.register_module("test");
+        ModuleHandle {
+            state,
+            global,
+            name: "test".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_record_read() {
+        let handle = create_handle();
+        handle.record_read("topic", 5);
+        handle.record_read("topic", 3);
+
+        let metrics = handle.state.collect();
+        assert_eq!(metrics.reads.get("topic").unwrap().count, 8);
+    }
+
+    #[test]
+    fn test_record_write() {
+        let handle = create_handle();
+        handle.record_write("topic", 10);
+
+        let metrics = handle.state.collect();
+        assert_eq!(metrics.writes.get("topic").unwrap().count, 10);
+    }
+
+    #[test]
+    fn test_pending_guard() {
+        let handle = create_handle();
+
+        {
+            let _guard = handle.start_read("topic");
+            // While guard is held, pending should be set
+            let state = handle.state.get_or_create_read("topic");
+            assert!(state.pending_since.read().is_some());
+        }
+
+        // After guard is dropped, pending should be cleared
+        let state = handle.state.get_or_create_read("topic");
+        assert!(state.pending_since.read().is_none());
+    }
+}

--- a/buswatch-sdk/src/instrumentor.rs
+++ b/buswatch-sdk/src/instrumentor.rs
@@ -1,0 +1,257 @@
+//! The main Instrumentor type for collecting and emitting metrics.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::handle::ModuleHandle;
+use crate::output::Output;
+use crate::state::GlobalState;
+
+/// The main entry point for instrumenting a message bus.
+///
+/// An Instrumentor collects metrics from registered modules and periodically
+/// emits snapshots to configured outputs.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use buswatch_sdk::{Instrumentor, Output};
+/// use std::time::Duration;
+///
+/// #[tokio::main]
+/// async fn main() {
+///     let instrumentor = Instrumentor::builder()
+///         .output(Output::file("metrics.json"))
+///         .interval(Duration::from_secs(1))
+///         .build();
+///
+///     let handle = instrumentor.register("my-service");
+///
+///     // Start background emission
+///     instrumentor.start();
+///
+///     // Record some metrics
+///     handle.record_read("events", 10);
+///     handle.record_write("results", 10);
+///
+///     // Keep the application running
+///     tokio::time::sleep(Duration::from_secs(5)).await;
+/// }
+/// ```
+#[derive(Debug)]
+pub struct Instrumentor {
+    state: Arc<GlobalState>,
+    outputs: Arc<Vec<Output>>,
+    interval: Duration,
+}
+
+impl Instrumentor {
+    /// Create a new instrumentor with default settings.
+    ///
+    /// By default, no outputs are configured and the interval is 1 second.
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(GlobalState::default()),
+            outputs: Arc::new(Vec::new()),
+            interval: Duration::from_secs(1),
+        }
+    }
+
+    /// Create a builder for configuring the instrumentor.
+    pub fn builder() -> InstrumentorBuilder {
+        InstrumentorBuilder::new()
+    }
+
+    /// Register a module and get a handle for recording metrics.
+    ///
+    /// If a module with this name already exists, returns a handle to
+    /// the existing module.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The module name (e.g., "order-processor", "notification-sender")
+    pub fn register(&self, name: &str) -> ModuleHandle {
+        let module_state = self.state.register_module(name);
+        ModuleHandle {
+            state: module_state,
+            global: self.state.clone(),
+            name: name.to_string(),
+        }
+    }
+
+    /// Collect a snapshot of all current metrics.
+    ///
+    /// This is useful if you want to emit snapshots manually rather than
+    /// using the background emission.
+    pub fn collect(&self) -> buswatch_types::Snapshot {
+        self.state.collect()
+    }
+
+    /// Start background emission of snapshots.
+    ///
+    /// This spawns a tokio task that periodically collects and emits
+    /// snapshots to all configured outputs.
+    ///
+    /// Returns a handle that can be used to stop the emission.
+    #[cfg(feature = "tokio")]
+    pub fn start(&self) -> EmissionHandle {
+        use tokio::sync::watch;
+
+        let (stop_tx, stop_rx) = watch::channel(false);
+        let state = self.state.clone();
+        let outputs = self.outputs.clone();
+        let interval = self.interval;
+
+        tokio::spawn(async move {
+            let mut interval_timer = tokio::time::interval(interval);
+            let mut stop_rx = stop_rx;
+
+            loop {
+                tokio::select! {
+                    _ = interval_timer.tick() => {
+                        let snapshot = state.collect();
+                        for output in outputs.iter() {
+                            let _ = output.emit(&snapshot).await;
+                        }
+                    }
+                    _ = stop_rx.changed() => {
+                        if *stop_rx.borrow() {
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+
+        EmissionHandle { stop_tx }
+    }
+
+    /// Emit a snapshot to all outputs immediately.
+    #[cfg(feature = "tokio")]
+    pub async fn emit_now(&self) {
+        let snapshot = self.state.collect();
+        for output in self.outputs.iter() {
+            let _ = output.emit(&snapshot).await;
+        }
+    }
+}
+
+impl Default for Instrumentor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Builder for configuring an Instrumentor.
+#[derive(Debug, Default)]
+pub struct InstrumentorBuilder {
+    outputs: Vec<Output>,
+    interval: Option<Duration>,
+}
+
+impl InstrumentorBuilder {
+    /// Create a new builder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add an output destination.
+    ///
+    /// Multiple outputs can be added; snapshots will be emitted to all of them.
+    pub fn output(mut self, output: Output) -> Self {
+        self.outputs.push(output);
+        self
+    }
+
+    /// Set the emission interval.
+    ///
+    /// Defaults to 1 second if not specified.
+    pub fn interval(mut self, interval: Duration) -> Self {
+        self.interval = Some(interval);
+        self
+    }
+
+    /// Build the instrumentor.
+    pub fn build(self) -> Instrumentor {
+        Instrumentor {
+            state: Arc::new(GlobalState::default()),
+            outputs: Arc::new(self.outputs),
+            interval: self.interval.unwrap_or(Duration::from_secs(1)),
+        }
+    }
+}
+
+/// Handle for controlling background emission.
+///
+/// Drop this handle to stop emission, or call `stop()` explicitly.
+#[cfg(feature = "tokio")]
+pub struct EmissionHandle {
+    stop_tx: tokio::sync::watch::Sender<bool>,
+}
+
+#[cfg(feature = "tokio")]
+impl EmissionHandle {
+    /// Stop background emission.
+    pub fn stop(self) {
+        let _ = self.stop_tx.send(true);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_instrumentor_new() {
+        let instrumentor = Instrumentor::new();
+        let handle = instrumentor.register("test-module");
+        assert_eq!(handle.name(), "test-module");
+    }
+
+    #[test]
+    fn test_instrumentor_collect() {
+        let instrumentor = Instrumentor::new();
+        let handle = instrumentor.register("producer");
+
+        handle.record_write("events", 100);
+        handle.record_read("commands", 50);
+
+        let snapshot = instrumentor.collect();
+        assert_eq!(snapshot.modules.len(), 1);
+
+        let metrics = snapshot.modules.get("producer").unwrap();
+        assert_eq!(metrics.writes.get("events").unwrap().count, 100);
+        assert_eq!(metrics.reads.get("commands").unwrap().count, 50);
+    }
+
+    #[test]
+    fn test_multiple_modules() {
+        let instrumentor = Instrumentor::new();
+
+        let producer = instrumentor.register("producer");
+        let consumer = instrumentor.register("consumer");
+
+        producer.record_write("events", 100);
+        consumer.record_read("events", 95);
+
+        let snapshot = instrumentor.collect();
+        assert_eq!(snapshot.modules.len(), 2);
+
+        // Check backlog computation
+        let consumer_metrics = snapshot.modules.get("consumer").unwrap();
+        let events_read = consumer_metrics.reads.get("events").unwrap();
+        assert_eq!(events_read.count, 95);
+        assert_eq!(events_read.backlog, Some(5)); // 100 written - 95 read = 5 backlog
+    }
+
+    #[test]
+    fn test_builder() {
+        let instrumentor = Instrumentor::builder()
+            .output(Output::file("test.json"))
+            .interval(Duration::from_millis(500))
+            .build();
+
+        assert_eq!(instrumentor.interval, Duration::from_millis(500));
+        assert_eq!(instrumentor.outputs.len(), 1);
+    }
+}

--- a/buswatch-sdk/src/lib.rs
+++ b/buswatch-sdk/src/lib.rs
@@ -1,0 +1,54 @@
+//! # buswatch-sdk
+//!
+//! Instrumentation SDK for emitting message bus metrics to buswatch.
+//!
+//! This crate provides a simple API for instrumenting any message bus system
+//! to emit metrics that can be consumed by buswatch or other monitoring tools.
+//!
+//! ## Quick Start
+//!
+//! ```rust,no_run
+//! use buswatch_sdk::{Instrumentor, Output};
+//! use std::time::Duration;
+//!
+//! #[tokio::main]
+//! async fn main() {
+//!     // Create an instrumentor that emits snapshots every second
+//!     let instrumentor = Instrumentor::builder()
+//!         .output(Output::file("metrics.json"))
+//!         .interval(Duration::from_secs(1))
+//!         .build();
+//!
+//!     // Register a module and get a handle for recording metrics
+//!     let handle = instrumentor.register("my-service");
+//!
+//!     // Record metrics as your service processes messages
+//!     handle.record_read("orders.new", 1);
+//!     handle.record_write("orders.processed", 1);
+//!
+//!     // Start background emission (non-blocking)
+//!     instrumentor.start();
+//!
+//!     // ... your application runs ...
+//! }
+//! ```
+//!
+//! ## Features
+//!
+//! - **Simple API**: Just `record_read()` and `record_write()`
+//! - **Multiple outputs**: File, TCP, or custom channel
+//! - **Background emission**: Automatic periodic snapshots
+//! - **Thread-safe**: Use from any thread or async task
+//! - **Low overhead**: Lock-free counters where possible
+
+mod handle;
+mod instrumentor;
+mod output;
+mod state;
+
+pub use handle::ModuleHandle;
+pub use instrumentor::{Instrumentor, InstrumentorBuilder};
+pub use output::Output;
+
+// Re-export types for convenience
+pub use buswatch_types::{Microseconds, ModuleMetrics, ReadMetrics, Snapshot, WriteMetrics};

--- a/buswatch-sdk/src/output.rs
+++ b/buswatch-sdk/src/output.rs
@@ -1,0 +1,104 @@
+//! Output backends for emitting snapshots.
+
+use std::path::PathBuf;
+
+use buswatch_types::Snapshot;
+
+/// Output destination for snapshots.
+///
+/// Configure where the instrumentor should emit snapshots.
+#[derive(Debug, Clone)]
+pub enum Output {
+    /// Write snapshots to a JSON file.
+    ///
+    /// The file is overwritten with each snapshot.
+    File(PathBuf),
+
+    /// Send snapshots to a TCP server.
+    ///
+    /// Each snapshot is sent as a newline-delimited JSON message.
+    Tcp(String),
+
+    /// Send snapshots through a channel.
+    ///
+    /// Use `Output::channel()` to create this variant and get the receiver.
+    #[cfg(feature = "tokio")]
+    Channel(tokio::sync::mpsc::Sender<Snapshot>),
+}
+
+impl Output {
+    /// Create a file output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use buswatch_sdk::Output;
+    ///
+    /// let output = Output::file("metrics.json");
+    /// ```
+    pub fn file(path: impl Into<PathBuf>) -> Self {
+        Output::File(path.into())
+    }
+
+    /// Create a TCP output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use buswatch_sdk::Output;
+    ///
+    /// let output = Output::tcp("localhost:9090");
+    /// ```
+    pub fn tcp(addr: impl Into<String>) -> Self {
+        Output::Tcp(addr.into())
+    }
+
+    /// Create a channel output and return both the output and receiver.
+    ///
+    /// This is useful for integrating with your own snapshot handling.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use buswatch_sdk::Output;
+    ///
+    /// let (output, mut rx) = Output::channel(16);
+    ///
+    /// // Later, receive snapshots
+    /// // while let Some(snapshot) = rx.recv().await {
+    /// //     println!("Got snapshot with {} modules", snapshot.len());
+    /// // }
+    /// ```
+    #[cfg(feature = "tokio")]
+    pub fn channel(buffer: usize) -> (Self, tokio::sync::mpsc::Receiver<Snapshot>) {
+        let (tx, rx) = tokio::sync::mpsc::channel(buffer);
+        (Output::Channel(tx), rx)
+    }
+
+    /// Emit a snapshot to this output.
+    #[cfg(feature = "tokio")]
+    pub(crate) async fn emit(&self, snapshot: &Snapshot) -> std::io::Result<()> {
+        match self {
+            Output::File(path) => {
+                let json = serde_json::to_string_pretty(snapshot)?;
+                tokio::fs::write(path, json).await?;
+            }
+            Output::Tcp(addr) => {
+                use tokio::io::AsyncWriteExt;
+                use tokio::net::TcpStream;
+
+                // Try to connect and send (best effort)
+                if let Ok(mut stream) = TcpStream::connect(addr).await {
+                    let json = serde_json::to_string(snapshot)?;
+                    let _ = stream.write_all(json.as_bytes()).await;
+                    let _ = stream.write_all(b"\n").await;
+                }
+            }
+            Output::Channel(tx) => {
+                // Best effort send (don't block if channel is full)
+                let _ = tx.try_send(snapshot.clone());
+            }
+        }
+        Ok(())
+    }
+}

--- a/buswatch-sdk/src/state.rs
+++ b/buswatch-sdk/src/state.rs
@@ -1,0 +1,238 @@
+//! Internal state management for metrics collection.
+
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
+
+use buswatch_types::{Microseconds, ModuleMetrics, ReadMetrics, Snapshot, WriteMetrics};
+use parking_lot::RwLock;
+
+/// Thread-safe metrics for a single topic read stream.
+#[derive(Debug, Default)]
+pub struct ReadState {
+    pub count: AtomicU64,
+    pub pending_since: RwLock<Option<Instant>>,
+}
+
+/// Thread-safe metrics for a single topic write stream.
+#[derive(Debug, Default)]
+pub struct WriteState {
+    pub count: AtomicU64,
+    pub pending_since: RwLock<Option<Instant>>,
+}
+
+/// Thread-safe metrics for a single module.
+#[derive(Debug, Default)]
+pub struct ModuleState {
+    pub reads: RwLock<BTreeMap<String, Arc<ReadState>>>,
+    pub writes: RwLock<BTreeMap<String, Arc<WriteState>>>,
+}
+
+impl ModuleState {
+    /// Get or create a read state for a topic.
+    pub fn get_or_create_read(&self, topic: &str) -> Arc<ReadState> {
+        // Fast path: check if it exists
+        {
+            let reads = self.reads.read();
+            if let Some(state) = reads.get(topic) {
+                return state.clone();
+            }
+        }
+
+        // Slow path: create it
+        // Double-check after acquiring write lock
+        let mut reads = self.reads.write();
+        reads
+            .entry(topic.to_string())
+            .or_insert_with(|| Arc::new(ReadState::default()))
+            .clone()
+    }
+
+    /// Get or create a write state for a topic.
+    pub fn get_or_create_write(&self, topic: &str) -> Arc<WriteState> {
+        // Fast path: check if it exists
+        {
+            let writes = self.writes.read();
+            if let Some(state) = writes.get(topic) {
+                return state.clone();
+            }
+        }
+
+        // Slow path: create it
+        let mut writes = self.writes.write();
+        writes
+            .entry(topic.to_string())
+            .or_insert_with(|| Arc::new(WriteState::default()))
+            .clone()
+    }
+
+    /// Collect current metrics into a ModuleMetrics snapshot.
+    pub fn collect(&self) -> ModuleMetrics {
+        let now = Instant::now();
+
+        let reads = self
+            .reads
+            .read()
+            .iter()
+            .map(|(topic, state)| {
+                let count = state.count.load(Ordering::Relaxed);
+                let pending = state.pending_since.read().map(|since| {
+                    let duration = now.duration_since(since);
+                    Microseconds::from(duration)
+                });
+
+                (
+                    topic.clone(),
+                    ReadMetrics {
+                        count,
+                        backlog: None, // SDK doesn't track backlog directly
+                        pending,
+                        rate: None, // Could compute if we track history
+                    },
+                )
+            })
+            .collect();
+
+        let writes = self
+            .writes
+            .read()
+            .iter()
+            .map(|(topic, state)| {
+                let count = state.count.load(Ordering::Relaxed);
+                let pending = state.pending_since.read().map(|since| {
+                    let duration = now.duration_since(since);
+                    Microseconds::from(duration)
+                });
+
+                (
+                    topic.clone(),
+                    WriteMetrics {
+                        count,
+                        pending,
+                        rate: None,
+                    },
+                )
+            })
+            .collect();
+
+        ModuleMetrics { reads, writes }
+    }
+}
+
+/// Global state for all modules.
+#[derive(Debug, Default)]
+pub struct GlobalState {
+    pub modules: RwLock<BTreeMap<String, Arc<ModuleState>>>,
+    /// Track total writes per topic across all modules (for computing backlog)
+    pub topic_write_counts: RwLock<BTreeMap<String, Arc<AtomicU64>>>,
+}
+
+impl GlobalState {
+    /// Register a new module or get existing one.
+    pub fn register_module(&self, name: &str) -> Arc<ModuleState> {
+        // Fast path
+        {
+            let modules = self.modules.read();
+            if let Some(state) = modules.get(name) {
+                return state.clone();
+            }
+        }
+
+        // Slow path
+        let mut modules = self.modules.write();
+        modules
+            .entry(name.to_string())
+            .or_insert_with(|| Arc::new(ModuleState::default()))
+            .clone()
+    }
+
+    /// Get or create a global write counter for a topic.
+    pub fn get_topic_write_counter(&self, topic: &str) -> Arc<AtomicU64> {
+        // Fast path
+        {
+            let counts = self.topic_write_counts.read();
+            if let Some(counter) = counts.get(topic) {
+                return counter.clone();
+            }
+        }
+
+        // Slow path
+        let mut counts = self.topic_write_counts.write();
+        counts
+            .entry(topic.to_string())
+            .or_insert_with(|| Arc::new(AtomicU64::new(0)))
+            .clone()
+    }
+
+    /// Collect all modules into a Snapshot.
+    pub fn collect(&self) -> Snapshot {
+        let modules = self.modules.read();
+        let topic_writes = self.topic_write_counts.read();
+
+        let mut snapshot = Snapshot::builder();
+
+        for (name, state) in modules.iter() {
+            let mut metrics = state.collect();
+
+            // Compute backlog for each read topic
+            for (topic, read_metrics) in metrics.reads.iter_mut() {
+                if let Some(total_writes) = topic_writes.get(topic) {
+                    let total = total_writes.load(Ordering::Relaxed);
+                    if total > read_metrics.count {
+                        read_metrics.backlog = Some(total - read_metrics.count);
+                    }
+                }
+            }
+
+            snapshot = snapshot.module_metrics(name.clone(), metrics);
+        }
+
+        snapshot.build()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_module_state_read_write() {
+        let state = ModuleState::default();
+
+        let read = state.get_or_create_read("topic1");
+        read.count.fetch_add(10, Ordering::Relaxed);
+
+        let write = state.get_or_create_write("topic2");
+        write.count.fetch_add(5, Ordering::Relaxed);
+
+        let metrics = state.collect();
+        assert_eq!(metrics.reads.get("topic1").unwrap().count, 10);
+        assert_eq!(metrics.writes.get("topic2").unwrap().count, 5);
+    }
+
+    #[test]
+    fn test_global_state_collect() {
+        let global = GlobalState::default();
+
+        let module1 = global.register_module("service-a");
+        let module2 = global.register_module("service-b");
+
+        module1
+            .get_or_create_read("events")
+            .count
+            .fetch_add(100, Ordering::Relaxed);
+        module2
+            .get_or_create_write("events")
+            .count
+            .fetch_add(100, Ordering::Relaxed);
+
+        // Track global writes for backlog computation
+        global
+            .get_topic_write_counter("events")
+            .fetch_add(100, Ordering::Relaxed);
+
+        let snapshot = global.collect();
+        assert_eq!(snapshot.modules.len(), 2);
+    }
+}


### PR DESCRIPTION
- Instrumentor: main entry point for collecting metrics
- ModuleHandle: per-module interface for recording reads/writes
- Output backends: file, TCP, and channel
- Background emission with configurable interval
- Thread-safe with lock-free counters
- Automatic backlog computation across modules
- PendingGuard for RAII-style pending tracking