### PR TITLE
Add performance benchmarks with criterion to buswatch-sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **buswatch-sdk**: Performance benchmarks with Criterion.rs (#17)
+  - Benchmark suite for `record_read()` and `record_write()` hot path latency
+  - Benchmark suite for `collect()` snapshot generation with varying module/topic counts
+  - Benchmark suite for concurrent increment throughput across multiple threads
+  - Benchmark suite for JSON serialization and deserialization performance
+  - HTML reports generated in `target/criterion/` for detailed analysis
 - **buswatch-sdk**: Prometheus exposition format export (`prometheus` feature)
   - HTTP server serving metrics at configurable endpoint
   - All metrics include `module` and `topic` labels

--- a/buswatch-sdk/Cargo.toml
+++ b/buswatch-sdk/Cargo.toml
@@ -38,3 +38,20 @@ http-body-util = { version = "0.1", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "record_operations"
+harness = false
+
+[[bench]]
+name = "snapshot_collection"
+harness = false
+
+[[bench]]
+name = "concurrent_throughput"
+harness = false
+
+[[bench]]
+name = "serialization"
+harness = false

--- a/buswatch-sdk/README.md
+++ b/buswatch-sdk/README.md
@@ -244,3 +244,26 @@ The SDK is designed to have minimal overhead:
 - Lazy snapshot collection (only when emitting)
 - Configurable emission interval to control I/O frequency
 - No allocations on the hot path (record_read/write)
+
+### Benchmarks
+
+The SDK includes comprehensive benchmarks using [Criterion.rs](https://github.com/bheisler/criterion.rs) to measure performance:
+
+```bash
+# Run all benchmarks
+cargo bench
+
+# Run specific benchmark suite
+cargo bench --bench record_operations
+cargo bench --bench snapshot_collection
+cargo bench --bench concurrent_throughput
+cargo bench --bench serialization
+```
+
+Benchmark suites:
+- **record_operations**: Measures latency of `record_read()` and `record_write()` operations
+- **snapshot_collection**: Measures `collect()` performance with varying module and topic counts
+- **concurrent_throughput**: Measures throughput under concurrent access from multiple threads
+- **serialization**: Measures JSON serialization and deserialization performance
+
+Results are saved to `target/criterion/` with HTML reports for detailed analysis.

--- a/buswatch-sdk/benches/concurrent_throughput.rs
+++ b/buswatch-sdk/benches/concurrent_throughput.rs
@@ -1,0 +1,232 @@
+use buswatch_sdk::Instrumentor;
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use std::sync::Arc;
+use std::thread;
+
+/// Benchmark concurrent increment throughput with varying thread counts
+fn bench_concurrent_increments_varying_threads(c: &mut Criterion) {
+    let mut group = c.benchmark_group("concurrent_increments");
+
+    for thread_count in [1, 2, 4, 8, 16].iter() {
+        group.throughput(Throughput::Elements(*thread_count as u64 * 1000));
+        group.bench_with_input(
+            BenchmarkId::new("threads", thread_count),
+            thread_count,
+            |b, &thread_count| {
+                b.iter(|| {
+                    let instrumentor = Arc::new(Instrumentor::new());
+                    let handle = Arc::new(instrumentor.register("bench-module"));
+
+                    let mut handles_vec = vec![];
+
+                    for _ in 0..thread_count {
+                        let handle_clone = Arc::clone(&handle);
+                        let join_handle = thread::spawn(move || {
+                            for _ in 0..1000 {
+                                handle_clone.record_read(black_box("test-topic"), black_box(1));
+                            }
+                        });
+                        handles_vec.push(join_handle);
+                    }
+
+                    for join_handle in handles_vec {
+                        join_handle.join().unwrap();
+                    }
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+/// Benchmark concurrent writes to same topic (high contention)
+fn bench_concurrent_writes_same_topic(c: &mut Criterion) {
+    let mut group = c.benchmark_group("concurrent_writes_same_topic");
+
+    for thread_count in [2, 4, 8].iter() {
+        group.throughput(Throughput::Elements(*thread_count as u64 * 1000));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(thread_count),
+            thread_count,
+            |b, &thread_count| {
+                b.iter(|| {
+                    let instrumentor = Arc::new(Instrumentor::new());
+                    let handle = Arc::new(instrumentor.register("bench-module"));
+
+                    let mut handles_vec = vec![];
+
+                    for _ in 0..thread_count {
+                        let handle_clone = Arc::clone(&handle);
+                        let join_handle = thread::spawn(move || {
+                            for _ in 0..1000 {
+                                handle_clone.record_write(black_box("shared-topic"), black_box(1));
+                            }
+                        });
+                        handles_vec.push(join_handle);
+                    }
+
+                    for join_handle in handles_vec {
+                        join_handle.join().unwrap();
+                    }
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+/// Benchmark concurrent reads to different topics (low contention)
+fn bench_concurrent_reads_different_topics(c: &mut Criterion) {
+    let mut group = c.benchmark_group("concurrent_reads_different_topics");
+
+    for thread_count in [2, 4, 8].iter() {
+        group.throughput(Throughput::Elements(*thread_count as u64 * 1000));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(thread_count),
+            thread_count,
+            |b, &thread_count| {
+                b.iter(|| {
+                    let instrumentor = Arc::new(Instrumentor::new());
+                    let handle = Arc::new(instrumentor.register("bench-module"));
+
+                    let mut handles_vec = vec![];
+
+                    for thread_id in 0..thread_count {
+                        let handle_clone = Arc::clone(&handle);
+                        let join_handle = thread::spawn(move || {
+                            let topic = format!("topic-{}", thread_id);
+                            for _ in 0..1000 {
+                                handle_clone.record_read(black_box(&topic), black_box(1));
+                            }
+                        });
+                        handles_vec.push(join_handle);
+                    }
+
+                    for join_handle in handles_vec {
+                        join_handle.join().unwrap();
+                    }
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+/// Benchmark concurrent mixed operations (reads and writes)
+fn bench_concurrent_mixed_operations(c: &mut Criterion) {
+    let mut group = c.benchmark_group("concurrent_mixed_operations");
+
+    for thread_count in [2, 4, 8].iter() {
+        group.throughput(Throughput::Elements(*thread_count as u64 * 2000));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(thread_count),
+            thread_count,
+            |b, &thread_count| {
+                b.iter(|| {
+                    let instrumentor = Arc::new(Instrumentor::new());
+                    let handle = Arc::new(instrumentor.register("bench-module"));
+
+                    let mut handles_vec = vec![];
+
+                    for thread_id in 0..thread_count {
+                        let handle_clone = Arc::clone(&handle);
+                        let join_handle = thread::spawn(move || {
+                            let input_topic = format!("input-{}", thread_id);
+                            let output_topic = format!("output-{}", thread_id);
+
+                            for _ in 0..1000 {
+                                handle_clone.record_read(black_box(&input_topic), black_box(1));
+                                handle_clone.record_write(black_box(&output_topic), black_box(1));
+                            }
+                        });
+                        handles_vec.push(join_handle);
+                    }
+
+                    for join_handle in handles_vec {
+                        join_handle.join().unwrap();
+                    }
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+/// Benchmark concurrent access from multiple modules
+fn bench_concurrent_multiple_modules(c: &mut Criterion) {
+    c.bench_function("concurrent_multiple_modules", |b| {
+        b.iter(|| {
+            let instrumentor = Arc::new(Instrumentor::new());
+
+            let mut handles_vec = vec![];
+
+            // 8 threads, each with their own module
+            for thread_id in 0..8 {
+                let instrumentor_clone = Arc::clone(&instrumentor);
+                let join_handle = thread::spawn(move || {
+                    let module_name = format!("module-{}", thread_id);
+                    let handle = instrumentor_clone.register(&module_name);
+
+                    for i in 0..500 {
+                        let topic = format!("topic-{}", i % 10);
+                        handle.record_read(black_box(&topic), black_box(1));
+                        handle.record_write(black_box(&topic), black_box(1));
+                    }
+                });
+                handles_vec.push(join_handle);
+            }
+
+            for join_handle in handles_vec {
+                join_handle.join().unwrap();
+            }
+        });
+    });
+}
+
+/// Benchmark concurrent increments with collect() calls
+fn bench_concurrent_with_collect(c: &mut Criterion) {
+    c.bench_function("concurrent_with_collect", |b| {
+        b.iter(|| {
+            let instrumentor = Arc::new(Instrumentor::new());
+            let handle = Arc::new(instrumentor.register("bench-module"));
+
+            let mut handles_vec = vec![];
+
+            // Spawn 4 writer threads
+            for thread_id in 0..4 {
+                let handle_clone = Arc::clone(&handle);
+                let join_handle = thread::spawn(move || {
+                    let topic = format!("topic-{}", thread_id);
+                    for _ in 0..500 {
+                        handle_clone.record_write(black_box(&topic), black_box(1));
+                    }
+                });
+                handles_vec.push(join_handle);
+            }
+
+            // Spawn 1 collector thread
+            let instrumentor_clone = Arc::clone(&instrumentor);
+            let collector_handle = thread::spawn(move || {
+                for _ in 0..10 {
+                    black_box(instrumentor_clone.collect());
+                }
+            });
+            handles_vec.push(collector_handle);
+
+            for join_handle in handles_vec {
+                join_handle.join().unwrap();
+            }
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_concurrent_increments_varying_threads,
+    bench_concurrent_writes_same_topic,
+    bench_concurrent_reads_different_topics,
+    bench_concurrent_mixed_operations,
+    bench_concurrent_multiple_modules,
+    bench_concurrent_with_collect
+);
+criterion_main!(benches);

--- a/buswatch-sdk/benches/record_operations.rs
+++ b/buswatch-sdk/benches/record_operations.rs
@@ -1,0 +1,105 @@
+use buswatch_sdk::Instrumentor;
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+
+/// Benchmark record_read latency (hot path)
+fn bench_record_read(c: &mut Criterion) {
+    let instrumentor = Instrumentor::new();
+    let handle = instrumentor.register("bench-module");
+
+    c.bench_function("record_read", |b| {
+        b.iter(|| {
+            handle.record_read(black_box("test-topic"), black_box(1));
+        });
+    });
+}
+
+/// Benchmark record_write latency (hot path)
+fn bench_record_write(c: &mut Criterion) {
+    let instrumentor = Instrumentor::new();
+    let handle = instrumentor.register("bench-module");
+
+    c.bench_function("record_write", |b| {
+        b.iter(|| {
+            handle.record_write(black_box("test-topic"), black_box(1));
+        });
+    });
+}
+
+/// Benchmark record_read with varying counts
+fn bench_record_read_varying_counts(c: &mut Criterion) {
+    let mut group = c.benchmark_group("record_read_varying_counts");
+    let instrumentor = Instrumentor::new();
+    let handle = instrumentor.register("bench-module");
+
+    for count in [1u64, 10, 100, 1000].iter() {
+        group.bench_with_input(BenchmarkId::from_parameter(count), count, |b, &count| {
+            b.iter(|| {
+                handle.record_read(black_box("test-topic"), black_box(count));
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Benchmark record_write with varying counts
+fn bench_record_write_varying_counts(c: &mut Criterion) {
+    let mut group = c.benchmark_group("record_write_varying_counts");
+    let instrumentor = Instrumentor::new();
+    let handle = instrumentor.register("bench-module");
+
+    for count in [1u64, 10, 100, 1000].iter() {
+        group.bench_with_input(BenchmarkId::from_parameter(count), count, |b, &count| {
+            b.iter(|| {
+                handle.record_write(black_box("test-topic"), black_box(count));
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Benchmark mixed read/write operations
+fn bench_mixed_operations(c: &mut Criterion) {
+    let instrumentor = Instrumentor::new();
+    let handle = instrumentor.register("bench-module");
+
+    c.bench_function("mixed_read_write", |b| {
+        b.iter(|| {
+            handle.record_read(black_box("input-topic"), black_box(1));
+            handle.record_write(black_box("output-topic"), black_box(1));
+        });
+    });
+}
+
+/// Benchmark operations across multiple topics
+fn bench_multiple_topics(c: &mut Criterion) {
+    let mut group = c.benchmark_group("multiple_topics");
+    let instrumentor = Instrumentor::new();
+    let handle = instrumentor.register("bench-module");
+
+    for topic_count in [1, 5, 10, 20].iter() {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(topic_count),
+            topic_count,
+            |b, &topic_count| {
+                b.iter(|| {
+                    for i in 0..topic_count {
+                        let topic = format!("topic-{}", i);
+                        handle.record_read(black_box(&topic), black_box(1));
+                    }
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_record_read,
+    bench_record_write,
+    bench_record_read_varying_counts,
+    bench_record_write_varying_counts,
+    bench_mixed_operations,
+    bench_multiple_topics
+);
+criterion_main!(benches);

--- a/buswatch-sdk/benches/serialization.rs
+++ b/buswatch-sdk/benches/serialization.rs
@@ -1,0 +1,228 @@
+use buswatch_sdk::Instrumentor;
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+
+/// Benchmark JSON serialization of snapshots with varying sizes
+fn bench_json_serialization_varying_sizes(c: &mut Criterion) {
+    let mut group = c.benchmark_group("json_serialization");
+
+    // Test different snapshot sizes
+    let configs = vec![
+        ("small", 1, 5),     // 1 module, 5 topics
+        ("medium", 5, 20),   // 5 modules, 20 topics each
+        ("large", 10, 50),   // 10 modules, 50 topics each
+        ("xlarge", 20, 100), // 20 modules, 100 topics each
+    ];
+
+    for (name, module_count, topic_count) in configs {
+        let instrumentor = Instrumentor::new();
+
+        // Create modules and populate with metrics
+        for i in 0..module_count {
+            let module_name = format!("module-{}", i);
+            let handle = instrumentor.register(&module_name);
+
+            for j in 0..topic_count {
+                let topic = format!("topic-{}", j);
+                handle.record_read(&topic, i * 1000 + j * 10);
+                handle.record_write(&topic, i * 500 + j * 5);
+            }
+        }
+
+        let snapshot = instrumentor.collect();
+
+        // Measure serialized size for throughput calculation
+        let json = serde_json::to_string(&snapshot).unwrap();
+        group.throughput(Throughput::Bytes(json.len() as u64));
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(name),
+            &snapshot,
+            |b, snapshot| {
+                b.iter(|| {
+                    black_box(serde_json::to_string(snapshot).unwrap());
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+/// Benchmark pretty-printed JSON serialization
+fn bench_json_serialization_pretty(c: &mut Criterion) {
+    let instrumentor = Instrumentor::new();
+
+    // Create a medium-sized snapshot
+    for i in 0..5 {
+        let module_name = format!("module-{}", i);
+        let handle = instrumentor.register(&module_name);
+
+        for j in 0..20 {
+            let topic = format!("topic-{}", j);
+            handle.record_read(&topic, i * 1000 + j * 10);
+            handle.record_write(&topic, i * 500 + j * 5);
+        }
+    }
+
+    let snapshot = instrumentor.collect();
+
+    let mut group = c.benchmark_group("json_serialization_pretty");
+    group.bench_function("pretty", |b| {
+        b.iter(|| {
+            black_box(serde_json::to_string_pretty(&snapshot).unwrap());
+        });
+    });
+    group.finish();
+}
+
+/// Benchmark JSON deserialization
+fn bench_json_deserialization(c: &mut Criterion) {
+    let instrumentor = Instrumentor::new();
+
+    // Create a snapshot and serialize it
+    for i in 0..5 {
+        let module_name = format!("module-{}", i);
+        let handle = instrumentor.register(&module_name);
+
+        for j in 0..20 {
+            let topic = format!("topic-{}", j);
+            handle.record_read(&topic, i * 1000 + j * 10);
+            handle.record_write(&topic, i * 500 + j * 5);
+        }
+    }
+
+    let snapshot = instrumentor.collect();
+    let json = serde_json::to_string(&snapshot).unwrap();
+
+    let mut group = c.benchmark_group("json_deserialization");
+    group.bench_function("deserialize", |b| {
+        b.iter(|| {
+            let _: buswatch_sdk::Snapshot = black_box(serde_json::from_str(&json).unwrap());
+        });
+    });
+    group.finish();
+}
+
+/// Benchmark serialization to Vec<u8> (bytes)
+fn bench_json_to_vec(c: &mut Criterion) {
+    let instrumentor = Instrumentor::new();
+
+    for i in 0..10 {
+        let module_name = format!("module-{}", i);
+        let handle = instrumentor.register(&module_name);
+
+        for j in 0..50 {
+            let topic = format!("topic-{}", j);
+            handle.record_read(&topic, i * 1000 + j * 10);
+            handle.record_write(&topic, i * 500 + j * 5);
+        }
+    }
+
+    let snapshot = instrumentor.collect();
+
+    let mut group = c.benchmark_group("json_to_vec");
+    group.bench_function("to_vec", |b| {
+        b.iter(|| {
+            black_box(serde_json::to_vec(&snapshot).unwrap());
+        });
+    });
+    group.finish();
+}
+
+/// Benchmark round-trip serialization (serialize + deserialize)
+fn bench_json_roundtrip(c: &mut Criterion) {
+    let instrumentor = Instrumentor::new();
+
+    for i in 0..5 {
+        let module_name = format!("module-{}", i);
+        let handle = instrumentor.register(&module_name);
+
+        for j in 0..20 {
+            let topic = format!("topic-{}", j);
+            handle.record_read(&topic, i * 1000 + j * 10);
+            handle.record_write(&topic, i * 500 + j * 5);
+        }
+    }
+
+    let snapshot = instrumentor.collect();
+
+    let mut group = c.benchmark_group("json_roundtrip");
+    group.bench_function("roundtrip", |b| {
+        b.iter(|| {
+            let json = serde_json::to_string(&snapshot).unwrap();
+            let _: buswatch_sdk::Snapshot = serde_json::from_str(&json).unwrap();
+        });
+    });
+    group.finish();
+}
+
+/// Benchmark serialization with minimal snapshot (empty)
+fn bench_json_serialization_empty(c: &mut Criterion) {
+    let instrumentor = Instrumentor::new();
+    let snapshot = instrumentor.collect();
+
+    let mut group = c.benchmark_group("json_serialization_empty");
+    group.bench_function("empty", |b| {
+        b.iter(|| {
+            black_box(serde_json::to_string(&snapshot).unwrap());
+        });
+    });
+    group.finish();
+}
+
+/// Benchmark serialization with realistic snapshot
+fn bench_json_serialization_realistic(c: &mut Criterion) {
+    let instrumentor = Instrumentor::new();
+
+    // Simulate a realistic application with multiple services
+    let services = vec![
+        (
+            "order-service",
+            vec!["orders.new", "orders.confirmed", "orders.cancelled"],
+        ),
+        (
+            "payment-service",
+            vec!["payments.pending", "payments.completed", "payments.failed"],
+        ),
+        (
+            "inventory-service",
+            vec!["inventory.reserved", "inventory.released"],
+        ),
+        (
+            "notification-service",
+            vec!["notifications.email", "notifications.sms"],
+        ),
+    ];
+
+    for (service_name, topics) in services {
+        let handle = instrumentor.register(service_name);
+
+        for (idx, topic) in topics.iter().enumerate() {
+            handle.record_read(topic, (idx as u64 + 1) * 1000);
+            handle.record_write(topic, (idx as u64 + 1) * 500);
+        }
+    }
+
+    let snapshot = instrumentor.collect();
+    let json = serde_json::to_string(&snapshot).unwrap();
+
+    let mut group = c.benchmark_group("json_serialization_realistic");
+    group.throughput(Throughput::Bytes(json.len() as u64));
+    group.bench_function("realistic", |b| {
+        b.iter(|| {
+            black_box(serde_json::to_string(&snapshot).unwrap());
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_json_serialization_varying_sizes,
+    bench_json_serialization_pretty,
+    bench_json_deserialization,
+    bench_json_to_vec,
+    bench_json_roundtrip,
+    bench_json_serialization_empty,
+    bench_json_serialization_realistic
+);
+criterion_main!(benches);

--- a/buswatch-sdk/benches/snapshot_collection.rs
+++ b/buswatch-sdk/benches/snapshot_collection.rs
@@ -1,0 +1,152 @@
+use buswatch_sdk::Instrumentor;
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+
+/// Benchmark collect() with a single module and varying topic counts
+fn bench_collect_single_module_varying_topics(c: &mut Criterion) {
+    let mut group = c.benchmark_group("collect_single_module");
+
+    for topic_count in [1, 5, 10, 50, 100].iter() {
+        let instrumentor = Instrumentor::new();
+        let handle = instrumentor.register("bench-module");
+
+        // Pre-populate with topics
+        for i in 0..*topic_count {
+            let topic = format!("topic-{}", i);
+            handle.record_read(&topic, 100);
+            handle.record_write(&topic, 50);
+        }
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(topic_count),
+            topic_count,
+            |b, _| {
+                b.iter(|| {
+                    black_box(instrumentor.collect());
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+/// Benchmark collect() with varying module counts
+fn bench_collect_varying_modules(c: &mut Criterion) {
+    let mut group = c.benchmark_group("collect_varying_modules");
+
+    for module_count in [1, 5, 10, 20, 50].iter() {
+        let instrumentor = Instrumentor::new();
+        let mut handles = Vec::new();
+
+        // Create multiple modules
+        for i in 0..*module_count {
+            let module_name = format!("module-{}", i);
+            let handle = instrumentor.register(&module_name);
+
+            // Add some metrics to each module
+            for j in 0..5 {
+                let topic = format!("topic-{}", j);
+                handle.record_read(&topic, 100);
+                handle.record_write(&topic, 50);
+            }
+
+            handles.push(handle);
+        }
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(module_count),
+            module_count,
+            |b, _| {
+                b.iter(|| {
+                    black_box(instrumentor.collect());
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+/// Benchmark collect() with realistic workload (multiple modules, multiple topics)
+fn bench_collect_realistic_workload(c: &mut Criterion) {
+    let instrumentor = Instrumentor::new();
+
+    // Simulate a realistic scenario: 10 modules, each with 20 topics
+    for i in 0..10 {
+        let module_name = format!("service-{}", i);
+        let handle = instrumentor.register(&module_name);
+
+        for j in 0..20 {
+            let topic = format!("events.{}.topic-{}", i, j);
+            handle.record_read(&topic, i * 1000 + j * 10);
+            handle.record_write(&topic, i * 500 + j * 5);
+        }
+    }
+
+    c.bench_function("collect_realistic_workload", |b| {
+        b.iter(|| {
+            black_box(instrumentor.collect());
+        });
+    });
+}
+
+/// Benchmark collect() after active recording (measures impact of concurrent updates)
+fn bench_collect_with_active_recording(c: &mut Criterion) {
+    let instrumentor = Instrumentor::new();
+    let handle = instrumentor.register("active-module");
+
+    // Pre-populate
+    for i in 0..10 {
+        let topic = format!("topic-{}", i);
+        handle.record_read(&topic, 1000);
+        handle.record_write(&topic, 500);
+    }
+
+    c.bench_function("collect_with_active_recording", |b| {
+        b.iter(|| {
+            // Simulate some concurrent updates
+            handle.record_read("topic-0", 1);
+            handle.record_write("topic-1", 1);
+
+            // Collect snapshot
+            black_box(instrumentor.collect());
+        });
+    });
+}
+
+/// Benchmark empty collect() to measure baseline overhead
+fn bench_collect_empty(c: &mut Criterion) {
+    let instrumentor = Instrumentor::new();
+
+    c.bench_function("collect_empty", |b| {
+        b.iter(|| {
+            black_box(instrumentor.collect());
+        });
+    });
+}
+
+/// Benchmark collect() with only registered modules (no metrics)
+fn bench_collect_modules_no_metrics(c: &mut Criterion) {
+    let instrumentor = Instrumentor::new();
+
+    // Register 10 modules but don't record any metrics
+    for i in 0..10 {
+        let module_name = format!("module-{}", i);
+        instrumentor.register(&module_name);
+    }
+
+    c.bench_function("collect_modules_no_metrics", |b| {
+        b.iter(|| {
+            black_box(instrumentor.collect());
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_collect_single_module_varying_topics,
+    bench_collect_varying_modules,
+    bench_collect_realistic_workload,
+    bench_collect_with_active_recording,
+    bench_collect_empty,
+    bench_collect_modules_no_metrics
+);
+criterion_main!(benches);


### PR DESCRIPTION
Closes #17

## Summary
This PR adds comprehensive performance benchmarks to `buswatch-sdk` using Criterion.rs to measure and track performance of critical SDK operations.

## Changes
- ✅ Add criterion 0.5 as dev-dependency with html_reports feature
- ✅ Create 4 benchmark suites covering all requirements from #17:
  - **record_operations**: Measures `record_read()` and `record_write()` hot path latency
  - **snapshot_collection**: Measures `collect()` snapshot generation time with varying module/topic counts
  - **concurrent_throughput**: Measures concurrent increment throughput across multiple threads
  - **serialization**: Measures JSON serialization and deserialization performance
- ✅ Add [[bench]] sections to Cargo.toml for each benchmark suite
- ✅ Update README.md with benchmark documentation and usage examples
- ✅ Update CHANGELOG.md with benchmark feature details

## Benchmark Coverage
### record_operations
- Single operation latency for record_read and record_write
- Varying message counts (1, 10, 100, 1000)
- Mixed read/write operations
- Multiple topics

### snapshot_collection
- Varying topic counts (1, 5, 10, 50, 100)
- Varying module counts (1, 5, 10, 20, 50)
- Realistic workload scenarios
- Empty snapshots (baseline)

### concurrent_throughput
- Varying thread counts (1, 2, 4, 8, 16)
- High contention (same topic) vs low contention (different topics)
- Mixed concurrent operations
- Concurrent collect() calls

### serialization
- Varying snapshot sizes (small, medium, large, xlarge)
- Pretty-printed JSON
- Deserialization
- Round-trip serialization
- Realistic application scenarios

## Usage
```bash
# Run all benchmarks
cargo bench

# Run specific benchmark suite
cargo bench --bench record_operations
cargo bench --bench snapshot_collection
cargo bench --bench concurrent_throughput
cargo bench --bench serialization
```

Results are saved to `target/criterion/` with HTML reports for detailed analysis.

## Testing
- ✅ All benchmarks compile successfully
- ✅ All benchmarks run without errors (tested with `--test` flag)
- ✅ All existing tests pass
- ✅ Documentation builds correctly