### PR TITLE
feat(tui): Add CSV export format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - All metrics include `module` and `topic` labels
   - Health check endpoints (`/health`, `/healthz`) for Kubernetes probes
   - Metrics: read/write counts, backlog, pending seconds, rates
+- **buswatch-tui**: CSV export format (press `E` for CSV, `e` for JSON)
 
 ## [0.1.0] - 2025-12-21
 

--- a/buswatch-tui/src/events.rs
+++ b/buswatch-tui/src/events.rs
@@ -127,10 +127,23 @@ pub fn handle_key_event(app: &mut App, key: KeyEvent) {
             }
         }
 
-        // Export
+        // Export JSON
         KeyCode::Char('e') => {
             let export_path = std::path::PathBuf::from("monitor_export.json");
             match app.export_state(&export_path) {
+                Ok(()) => {
+                    app.set_status_message(format!("Exported to {}", export_path.display()));
+                }
+                Err(e) => {
+                    app.set_status_message(format!("Export failed: {}", e));
+                }
+            }
+        }
+
+        // Export CSV
+        KeyCode::Char('E') => {
+            let export_path = std::path::PathBuf::from("monitor_export.csv");
+            match app.export_state_csv(&export_path) {
                 Ok(()) => {
                     app.set_status_message(format!("Exported to {}", export_path.display()));
                 }

--- a/buswatch-tui/src/ui/common.rs
+++ b/buswatch-tui/src/ui/common.rs
@@ -225,6 +225,7 @@ pub fn render_help(frame: &mut Frame, app: &App, area: Rect) {
         )]),
         Line::from("  r         Reload data"),
         Line::from("  e         Export to JSON"),
+        Line::from("  E         Export to CSV"),
         Line::from("  q         Quit"),
         Line::from(""),
         Line::from(vec![Span::styled(


### PR DESCRIPTION
## Summary
Adds CSV export functionality to the TUI, complementing the existing JSON export.

## Changes
- Add `export_state_csv()` method to App
- Add `E` keybinding for CSV export (`e` remains for JSON)
- Add `csv_escape()` helper for proper CSV formatting
- Update help text with new keybinding
- Update CHANGELOG

## CSV Format
```csv
Module,Topic,Type,Count,Backlog,Pending,Health
order-processor,orders.new,Read,1500,23,150ms,OK
order-processor,orders.processed,Write,1497,,,OK
```

## Usage
- Press `E` in the TUI to export to `monitor_export.csv`
- Press `e` to export to `monitor_export.json` (unchanged)

## Testing
All 62 TUI tests pass.

Closes #32